### PR TITLE
feature(VegaLite): Add a demo of rendering VegaLite specs

### DIFF
--- a/hansroslinger/package-lock.json
+++ b/hansroslinger/package-lock.json
@@ -9,8 +9,9 @@
       "version": "0.1.0",
       "dependencies": {
         "next": "15.2.4",
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-vega": "^7.6.0",
         "vega": "^6.1.2",
         "vega-embed": "^7.0.2",
         "vega-lite": "^6.1.0"
@@ -19,8 +20,8 @@
         "@eslint/eslintrc": "^3",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
-        "@types/react": "^19",
-        "@types/react-dom": "^19",
+        "@types/react": "^18",
+        "@types/react-dom": "^18",
         "eslint": "^9",
         "eslint-config-next": "15.2.4",
         "tailwindcss": "^4",
@@ -843,6 +844,19 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.40.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.40.1.tgz",
+      "integrity": "sha512-XiK5z70PEFEFqcNj3/zRSz/qX4bp4QIraTy9QjwJAb/Z8GM7kVUsD0Uk8maIPeTyPCP03ChdI+VVmJriKYbRHQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1156,24 +1170,30 @@
         "undici-types": "~6.19.2"
       }
     },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.14",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.14.tgz",
+      "integrity": "sha512-gNMvNH49DJ7OJYv+KAKn0Xp45p8PLl6zo2YnvDIbTd4J6MER2BmWN49TG7n9LvkyihINxeKW8+3bfS2yDC9dzQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
-      "version": "19.0.12",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.12.tgz",
-      "integrity": "sha512-V6Ar115dBDrjbtXSrS+/Oruobc+qVbbUxDFC1RSbRqLt5SYvxxyIDrSC85RWml54g+jfNeEMZhEj7wW07ONQhA==",
-      "dev": true,
+      "version": "18.3.20",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.20.tgz",
+      "integrity": "sha512-IPaCZN7PShZK/3t6Q87pfTkRm6oLTd4vztyoj+cbHUF1g3FfVb2tFIL79uCRKEfv16AhqDMBywP2VW3KIZUvcg==",
       "license": "MIT",
       "dependencies": {
+        "@types/prop-types": "*",
         "csstype": "^3.0.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.0.4",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.4.tgz",
-      "integrity": "sha512-4fSQ8vWFkg+TGhePfUzVmat3eC14TXYSsiiDSLI0dVLsrm9gZFABjPy/Qu6TKgl1tq1Bu1yDsuQgY3A3DOjCcg==",
+      "version": "18.3.6",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.6.tgz",
+      "integrity": "sha512-nf22//wEbKXusP6E9pfOCDwFdHAX4u172eaJI4YkDRQEZiorm6KfYnSC2SWLDMVWUOWPERmJnN0ujeAfTBLvrw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^18.0.0"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2154,7 +2174,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -3218,7 +3237,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-glob": {
@@ -4203,7 +4221,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -4585,7 +4602,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
@@ -4807,7 +4823,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -5106,7 +5121,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
@@ -5146,32 +5160,109 @@
       "license": "MIT"
     },
     "node_modules/react": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
       "engines": {
         "node": ">=0.10.0"
       }
     },
     "node_modules/react-dom": {
-      "version": "19.1.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
-      "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
       "dependencies": {
-        "scheduler": "^0.26.0"
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
       },
       "peerDependencies": {
-        "react": "^19.1.0"
+        "react": "^18.3.1"
       }
     },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-vega": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/react-vega/-/react-vega-7.6.0.tgz",
+      "integrity": "sha512-2oMML4wH9qWLnZPRxJm06ozwrVN/K+nkjqdI5/ofWWsrBnnH4iB9rRKrsV8px0nlWgZrwfdCH4g5RUiyyJHWSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/react": "*",
+        "fast-deep-equal": "^3.1.1",
+        "prop-types": "^15.8.1",
+        "vega-embed": "^6.5.1"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/react-vega/node_modules/vega-embed": {
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/vega-embed/-/vega-embed-6.29.0.tgz",
+      "integrity": "sha512-PmlshTLtLFLgWtF/b23T1OwX53AugJ9RZ3qPE2c01VFAbgt3/GSNI/etzA/GzdrkceXFma+FDHNXUppKuM0U6Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "fast-json-patch": "^3.1.1",
+        "json-stringify-pretty-compact": "^4.0.0",
+        "semver": "^7.6.3",
+        "tslib": "^2.8.1",
+        "vega-interpreter": "^1.0.5",
+        "vega-schema-url-parser": "^2.2.0",
+        "vega-themes": "^2.15.0",
+        "vega-tooltip": "^0.35.2"
+      },
+      "peerDependencies": {
+        "vega": "^5.21.0",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/react-vega/node_modules/vega-interpreter": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-1.2.0.tgz",
+      "integrity": "sha512-p408/0IPevyR/bIKdXGNzOixkTYCkH83zNhGypRqDxd/qVrdJVrh9RcECOYx1MwEc6JTB1BeK2lArHiGGuG7Hw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^1.17.3"
+      }
+    },
+    "node_modules/react-vega/node_modules/vega-schema-url-parser": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/vega-schema-url-parser/-/vega-schema-url-parser-2.2.0.tgz",
+      "integrity": "sha512-yAtdBnfYOhECv9YC70H2gEiqfIbVkq09aaE4y/9V/ovEFmH9gPKaEgzIZqgT7PSPQjKhsNkb6jk6XvSoboxOBw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/react-vega/node_modules/vega-themes": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/vega-themes/-/vega-themes-2.15.0.tgz",
+      "integrity": "sha512-DicRAKG9z+23A+rH/3w3QjJvKnlGhSbbUXGjBvYGseZ1lvj9KQ0BXZ2NS/+MKns59LNpFNHGi9us/wMlci4TOA==",
+      "license": "BSD-3-Clause",
+      "peerDependencies": {
+        "vega": "*",
+        "vega-lite": "*"
+      }
+    },
+    "node_modules/react-vega/node_modules/vega-tooltip": {
+      "version": "0.35.2",
+      "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-0.35.2.tgz",
+      "integrity": "sha512-kuYcsAAKYn39ye5wKf2fq1BAxVcjoz0alvKp/G+7BWfIb94J0PHmwrJ5+okGefeStZnbXxINZEOKo7INHaj9GA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "vega-util": "^1.17.2"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.24.4"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -5376,10 +5467,13 @@
       "license": "MIT"
     },
     "node_modules/scheduler": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
-      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
-      "license": "MIT"
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
     },
     "node_modules/semver": {
       "version": "7.7.1",
@@ -6182,6 +6276,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-crossfilter/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-dataflow": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/vega-dataflow/-/vega-dataflow-6.0.0.tgz",
@@ -6192,6 +6292,12 @@
         "vega-loader": "^5.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-dataflow/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-embed": {
       "version": "7.0.2",
@@ -6229,6 +6335,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-encode/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-event-selector": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/vega-event-selector/-/vega-event-selector-4.0.0.tgz",
@@ -6245,6 +6357,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-expression/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-force": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vega-force/-/vega-force-5.0.0.tgz",
@@ -6255,6 +6373,12 @@
         "vega-dataflow": "^6.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-force/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-format": {
       "version": "2.0.0",
@@ -6268,6 +6392,12 @@
         "vega-time": "^3.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-format/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-functions": {
       "version": "6.0.0",
@@ -6288,6 +6418,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-functions/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-geo": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vega-geo/-/vega-geo-5.0.0.tgz",
@@ -6304,6 +6440,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-geo/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-hierarchy": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vega-hierarchy/-/vega-hierarchy-5.0.0.tgz",
@@ -6315,6 +6457,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-hierarchy/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-interpreter": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vega-interpreter/-/vega-interpreter-2.0.0.tgz",
@@ -6323,6 +6471,12 @@
       "dependencies": {
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-interpreter/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-label": {
       "version": "2.0.0",
@@ -6335,6 +6489,12 @@
         "vega-scenegraph": "^5.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-label/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-lite": {
       "version": "6.1.0",
@@ -6365,6 +6525,12 @@
         "vega": "^6.0.0"
       }
     },
+    "node_modules/vega-lite/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-loader": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vega-loader/-/vega-loader-5.0.0.tgz",
@@ -6378,6 +6544,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-loader/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-parser": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/vega-parser/-/vega-parser-7.0.0.tgz",
@@ -6390,6 +6562,12 @@
         "vega-scale": "^8.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-parser/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-projection": {
       "version": "2.0.0",
@@ -6414,6 +6592,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-regression/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-runtime": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/vega-runtime/-/vega-runtime-7.0.0.tgz",
@@ -6423,6 +6607,12 @@
         "vega-dataflow": "^6.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-runtime/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-scale": {
       "version": "8.0.0",
@@ -6438,6 +6628,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-scale/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-scenegraph": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vega-scenegraph/-/vega-scenegraph-5.0.0.tgz",
@@ -6451,6 +6647,12 @@
         "vega-scale": "^8.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-scenegraph/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-schema-url-parser": {
       "version": "3.0.2",
@@ -6468,6 +6670,12 @@
         "vega-expression": "^6.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-selections/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-statistics": {
       "version": "2.0.0",
@@ -6502,6 +6710,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-time/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-tooltip": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/vega-tooltip/-/vega-tooltip-1.0.0.tgz",
@@ -6513,6 +6727,12 @@
       "funding": {
         "url": "https://app.hubspot.com/payments/GyPC972GD9Rt"
       }
+    },
+    "node_modules/vega-tooltip/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-transforms": {
       "version": "5.0.0",
@@ -6527,6 +6747,12 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-transforms/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-typings": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/vega-typings/-/vega-typings-2.0.1.tgz",
@@ -6539,10 +6765,16 @@
         "vega-util": "^2.0.0"
       }
     },
-    "node_modules/vega-util": {
+    "node_modules/vega-typings/node_modules/vega-util": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
       "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-util": {
+      "version": "1.17.3",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-1.17.3.tgz",
+      "integrity": "sha512-nSNpZLUrRvFo46M5OK4O6x6f08WD1yOcEzHNlqivF+sDLSsVpstaF6fdJYwrbf/debFi2L9Tkp4gZQtssup9iQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/vega-view": {
@@ -6572,6 +6804,18 @@
         "vega-util": "^2.0.0"
       }
     },
+    "node_modules/vega-view-transforms/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega-view/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/vega-voronoi": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/vega-voronoi/-/vega-voronoi-5.0.0.tgz",
@@ -6582,6 +6826,12 @@
         "vega-dataflow": "^6.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-voronoi/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/vega-wordcloud": {
       "version": "5.0.0",
@@ -6595,6 +6845,18 @@
         "vega-statistics": "^2.0.0",
         "vega-util": "^2.0.0"
       }
+    },
+    "node_modules/vega-wordcloud/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/vega/node_modules/vega-util": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/vega-util/-/vega-util-2.0.0.tgz",
+      "integrity": "sha512-/ayLYX3VVqfkKJB1mG+xkOKiBVlfFZ9BfUB5vf7eVyIRork24sABXdeH4x+XeWuqDKnLBTDedotA+1a5MxlV2Q==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",

--- a/hansroslinger/package.json
+++ b/hansroslinger/package.json
@@ -11,8 +11,9 @@
   },
   "dependencies": {
     "next": "15.2.4",
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "react-vega": "^7.6.0",
     "vega": "^6.1.2",
     "vega-embed": "^7.0.2",
     "vega-lite": "^6.1.0"
@@ -21,8 +22,8 @@
     "@eslint/eslintrc": "^3",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
-    "@types/react": "^19",
-    "@types/react-dom": "^19",
+    "@types/react": "^18",
+    "@types/react-dom": "^18",
     "eslint": "^9",
     "eslint-config-next": "15.2.4",
     "tailwindcss": "^4",

--- a/hansroslinger/src/app/demo/page.tsx
+++ b/hansroslinger/src/app/demo/page.tsx
@@ -1,0 +1,79 @@
+"use client";
+import { VegaLite } from "react-vega";
+import { TopLevelSpec } from "vega-lite";
+const spec: TopLevelSpec = {
+  $schema: "https://vega.github.io/schema/vega-lite/v6.json",
+  description: "A simple bar chart with embedded data.",
+  data: {
+    values: [
+      {
+        a: "A",
+        b: 28,
+      },
+      {
+        a: "B",
+        b: 55,
+      },
+      {
+        a: "C",
+        b: 43,
+      },
+      {
+        a: "D",
+        b: 91,
+      },
+      {
+        a: "E",
+        b: 81,
+      },
+      {
+        a: "F",
+        b: 53,
+      },
+      {
+        a: "G",
+        b: 19,
+      },
+      {
+        a: "H",
+        b: 87,
+      },
+      {
+        a: "I",
+        b: 52,
+      },
+    ],
+  },
+  mark: {
+    type: "bar",
+    tooltip: true,
+  },
+  encoding: {
+    x: {
+      field: "a",
+      type: "nominal",
+      axis: {
+        labelAngle: 0,
+      },
+    },
+    y: {
+      field: "b",
+      type: "quantitative",
+    },
+    tooltip: [
+      { field: "a", type: "nominal", title: "Category" },
+      { field: "b", type: "quantitative", title: "Value" },
+    ],
+  },
+};
+const Demo = () => {
+  return (
+    <main className="flex-1 overflow-y-auto scroll-auto scroll-smooth lg:overflow-hidden">
+      <section className="flex items-center justify-center mb-8 mt-8">
+        <VegaLite spec={spec} />
+      </section>
+    </main>
+  );
+};
+
+export default Demo;


### PR DESCRIPTION
Using the 'react-vega' library, we can draw vegalite specs as react components.
You can test it by manually setting the url path to `/demo`