### PR TITLE
Bug: Fixes for size and resizing

### DIFF
--- a/hansroslinger/src/components/KonvaOverlay.tsx
+++ b/hansroslinger/src/components/KonvaOverlay.tsx
@@ -2,8 +2,9 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Stage, Layer, Rect } from "react-konva";
+import ImageVisual from "./visuals/ImageVisual";
 import { useVisualStore } from "store/visualsSlice";
-import { FILE_TYPE_JSON } from "constants/application";
+import { FILE_TYPE_JSON, FILE_TYPE_PNG } from "constants/application";
 import VegaLiteVisual from "./visuals/VegaLiteChartVisual";
 
 import { InteractionManager } from "./interactions/interactionManager";
@@ -45,22 +46,30 @@ const KonvaOverlay = () => {
         <div className="w-full h-full pointer-events-auto">
           <Stage width={dimensions.width} height={dimensions.height}>
             <Layer>
-              {visuals.map((visual) => 
-                  <Rect
-                    key={visual.assetId}
-                    x={visual.position.x}
-                    y={visual.position.y}
-                    width={visual.size.width}
-                    height={visual.size.height}
-                    fill="transparent"
-                  />
-                )}
+              {visuals.map((visual) => (
+                <Rect
+                  key={visual.assetId}
+                  x={visual.position.x}
+                  y={visual.position.y}
+                  width={visual.size.width}
+                  height={visual.size.height}
+                  fill="transparent"
+                />
+              ))}
             </Layer>
           </Stage>
           {visuals.map((visual) => {
             if (visual.uploadData.type === FILE_TYPE_JSON) {
               return (
                 <VegaLiteVisual key={visual.assetId} id={visual.assetId} />
+              );
+            } else if (visual.uploadData.type == FILE_TYPE_PNG) {
+              return (
+                <ImageVisual
+                  key={visual.assetId}
+                  id={visual.assetId}
+                  visual={visual}
+                />
               );
             }
             return null;

--- a/hansroslinger/src/components/KonvaOverlay.tsx
+++ b/hansroslinger/src/components/KonvaOverlay.tsx
@@ -2,9 +2,8 @@
 
 import React, { useEffect, useRef, useState } from "react";
 import { Stage, Layer, Rect } from "react-konva";
-import ImageVisual from "./visuals/ImageVisual";
 import { useVisualStore } from "store/visualsSlice";
-import { FILE_TYPE_JSON, FILE_TYPE_PNG } from "constants/application";
+import { FILE_TYPE_JSON } from "constants/application";
 import VegaLiteVisual from "./visuals/VegaLiteChartVisual";
 
 import { InteractionManager } from "./interactions/interactionManager";
@@ -46,31 +45,16 @@ const KonvaOverlay = () => {
         <div className="w-full h-full pointer-events-auto">
           <Stage width={dimensions.width} height={dimensions.height}>
             <Layer>
-              {visuals.map((visual) => {
-                if (visual.uploadData.type == FILE_TYPE_PNG) {
-                  return (
-                    <ImageVisual
-                      key={visual.assetId}
-                      id={visual.assetId}
-                      visual={visual}
-                    />
-                  );
-                } else if (visual.uploadData.type === FILE_TYPE_JSON) {
-                  const isHovered = visual.isHovered;
-                  return (
-                    <Rect
-                      key={visual.assetId}
-                      x={visual.position.x}
-                      y={visual.position.y}
-                      width={visual.size.width}
-                      height={visual.size.height}
-                      fill="transparent"
-                      stroke={isHovered ? "green" : "black"} // Highlight if hovered
-                      strokeWidth={isHovered ? 10 : 1} // Thicker border if hovered
-                    />
-                  );
-                }
-              })}
+              {visuals.map((visual) => 
+                  <Rect
+                    key={visual.assetId}
+                    x={visual.position.x}
+                    y={visual.position.y}
+                    width={visual.size.width}
+                    height={visual.size.height}
+                    fill="transparent"
+                  />
+                )}
             </Layer>
           </Stage>
           {visuals.map((visual) => {

--- a/hansroslinger/src/components/interactions/actions/handleResize.tsx
+++ b/hansroslinger/src/components/interactions/actions/handleResize.tsx
@@ -8,15 +8,37 @@ export const handleResize = (id: string, pointer: VisualPosition) => {
 
   const anchor = visual.position;
 
+  // Calculate aspect ratio with original size
+  const aspectRatio = visual.size.width / visual.size.height;
+
   // Calculate difference from anchor to pointer
   const dx = pointer.x - anchor.x;
   const dy = pointer.y - anchor.y;
 
-  // Use diagonal distance (uniform scaling)
-  const uniformDelta = Math.max(50, Math.max(dx, dy));
+  // Use the larger of dx or dy to determine scale
+  let newWidth = dx;
+  let newHeight = dy;
+
+  // Find which of dx or dy that has been enlarged more
+  if (dx / dy > aspectRatio) {
+    // Width is leading (enlarged more than height), use this value to calculate height based on ratio
+    newHeight = newWidth / aspectRatio;
+  } else {
+    // Height is leading, use this to calculate width based on ratio
+    newWidth = newHeight * aspectRatio;
+  }
+
+  // Define minimum size
+  // Minimum width is defined and minimum height will be calculated using the ratio
+  const minWidth = 50;
+  const minHeight = minWidth / aspectRatio;
+
+  // get the max between the minimum size and the new calculated size
+  newWidth = Math.max(minWidth, newWidth);
+  newHeight = Math.max(minHeight, newHeight);
 
   store.setVisualSize(id, {
-    width: uniformDelta,
-    height: uniformDelta,
+    width: newWidth,
+    height: newHeight,
   });
 };

--- a/hansroslinger/src/components/interactions/useMouseMockStream.tsx
+++ b/hansroslinger/src/components/interactions/useMouseMockStream.tsx
@@ -23,6 +23,22 @@ const isInTopRightCorner = (pos: { x: number; y: number }, visual: Visual) => {
 };
 
 /**
+ * Finds and return the highest index visual on a specified position
+ */
+const findVisualUnderPointer = (
+  pos: { x: number; y: number },
+  visuals: Visual[],
+) => {
+  return [...visuals].reverse().find((v) => {
+    const { x, y } = v.position;
+    const { width, height } = v.size;
+    return (
+      pos.x >= x && pos.x <= x + width && pos.y >= y && pos.y <= y + height
+    );
+  });
+};
+
+/**
  * Sets up mock interaction stream using the native mouse events.
  * Handles drag, resize, and hover interactions for visuals.
  */
@@ -59,13 +75,7 @@ export const useMouseMockStream = (manager: InteractionManager) => {
       const visuals = useVisualStore.getState().visuals;
 
       // Find the visual under the pointer
-      const visual = [...visuals].reverse().find((v) => {
-        const { x, y } = v.position;
-        const { width, height } = v.size;
-        return (
-          pos.x >= x && pos.x <= x + width && pos.y >= y && pos.y <= y + height
-        );
-      });
+      const visual = findVisualUnderPointer(pos, visuals);
 
       if (!visual) return;
 
@@ -105,13 +115,7 @@ export const useMouseMockStream = (manager: InteractionManager) => {
       const visuals = useVisualStore.getState().visuals;
 
       // Check which visual (if any) is currently under the pointer
-      const hoveredVisual = visuals.find((v) => {
-        const { x, y } = v.position;
-        const { width, height } = v.size;
-        return (
-          pos.x >= x && pos.x <= x + width && pos.y >= y && pos.y <= y + height
-        );
-      });
+      const hoveredVisual = findVisualUnderPointer(pos, visuals);
 
       // Only send hover events if the hovered visual changed
       if (hoveredVisual?.assetId !== hoveredVisualId.current) {

--- a/hansroslinger/src/components/visuals/VegaLiteChartVisual.tsx
+++ b/hansroslinger/src/components/visuals/VegaLiteChartVisual.tsx
@@ -67,7 +67,7 @@ const VegaLiteVisual = ({ id }: VegaLiteVisualProp) => {
 
   /**
    * Vegalite listen to resize events when the chart width and height is set to container
-   * This allows size updates without re-render (costly)
+   * This allows size updates without re-embed (costly)
    */
   useEffect(() => {
     window.dispatchEvent(new Event("resize"));

--- a/hansroslinger/src/components/visuals/VegaLiteChartVisual.tsx
+++ b/hansroslinger/src/components/visuals/VegaLiteChartVisual.tsx
@@ -65,7 +65,16 @@ const VegaLiteVisual = ({ id }: VegaLiteVisualProp) => {
   useEffect(() => {
     renderChart();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [id, size]);
+  }, [id]);
+
+  // Render when size updates
+  useEffect(() => {
+    if (visual && !visual.useOriginalSizeOnLoad) {
+      renderChart();
+    }
+    // don't want it to re-render when position change, only when size change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [size, visual?.useOriginalSizeOnLoad]);
 
   return (
     <div

--- a/hansroslinger/src/components/visuals/VegaLiteChartVisual.tsx
+++ b/hansroslinger/src/components/visuals/VegaLiteChartVisual.tsx
@@ -79,7 +79,9 @@ const VegaLiteVisual = ({ id }: VegaLiteVisualProp) => {
   return (
     <div
       id={id}
-      className={visual?.isHovered ? "outline-5 outline-offset-0 outline-green-500" : ""}
+      className={
+        visual?.isHovered ? "outline-5 outline-offset-0 outline-green-500" : ""
+      }
       ref={chartRef}
       style={{
         position: "absolute",

--- a/hansroslinger/src/store/visualsSlice.ts
+++ b/hansroslinger/src/store/visualsSlice.ts
@@ -19,6 +19,10 @@ type VisualsState = {
   setVisualSize: (assetId: string, size: VisualSize) => void;
   setVisualPosition: (assetId: string, position: VisualPosition) => void;
   setVisualHover: (assetId: string, isHovered: boolean) => void;
+  setUseOriginalSizeOnLoad: (
+    assetId: string,
+    useOriginalSizeOnLoad: boolean,
+  ) => void;
 };
 
 export const useVisualStore = create<VisualsState>()(
@@ -56,6 +60,8 @@ export const useVisualStore = create<VisualsState>()(
             position: { x: 0, y: 0 },
             size: { width: 300, height: 200 },
             isHovered: false,
+            // When selected, should default to original size
+            useOriginalSizeOnLoad: true,
           };
           return { visuals: [...state.visuals, visual] };
         }),
@@ -91,6 +97,16 @@ export const useVisualStore = create<VisualsState>()(
         set((state) => ({
           visuals: state.visuals.map((visual) =>
             visual.assetId === assetId ? { ...visual, isHovered } : visual,
+          ),
+        })),
+
+      // To determine whether original size (obtained from image or json file) will be used for render or the stored size
+      setUseOriginalSizeOnLoad: (assetId, useOriginalSizeOnLoad) =>
+        set((state) => ({
+          visuals: state.visuals.map((visual) =>
+            visual.assetId === assetId
+              ? { ...visual, useOriginalSizeOnLoad }
+              : visual,
           ),
         })),
     }),

--- a/hansroslinger/src/types/application.d.ts
+++ b/hansroslinger/src/types/application.d.ts
@@ -29,4 +29,6 @@ export type Visual = {
   position: VisualPosition;
   size: VisualSize;
   isHovered?: boolean;
+  // set to true when visual need to be set to original size, false otherwise
+  useOriginalSizeOnLoad: boolean;
 };


### PR DESCRIPTION
Several bugs found:

- resizing does not respect aspect ratio of visuals
- When first loaded, visuals is set with a default size instead of using what is defined in the png or json file
- Hover functionality is hovering over the bottom visual instated of the top
- Vegalite chart are being rendered and embed every time size changes, which is costly and reduce performance

Fixes:

- Fix resizing by calculating aspect ratio and respecting that when resizing
- Set visual to original size when first loaded
- Fix hovering by selecting the top visuals
- Set width and height of json file to "container" and dispatch "resize" event to resize vegalite instead of re-embedding it. Vegalite listen to "resize" event and if the width and height is set to "container", it will set the chart height according to the div
- Render image as a div instead of a child of the canvas, this allows us to control the indexing.

Before:
Hover:

https://github.com/user-attachments/assets/ce3c5486-5eea-4486-a294-54110e986d19



Resize:

https://github.com/user-attachments/assets/bbfcd274-5874-4bbb-bc7e-e6894f3aed66



After:
Hover:

https://github.com/user-attachments/assets/68091b8a-ff8f-42c4-8c24-4a5e05315004



Resize:

https://github.com/user-attachments/assets/b07e668c-76dd-453f-9cf2-bc3078261a66

