### PR TITLE
Feature/interaction integration

### DIFF
--- a/hansroslinger/src/app/detection/Gesture.ts
+++ b/hansroslinger/src/app/detection/Gesture.ts
@@ -45,7 +45,7 @@ class OpenPalm extends Gesture {
     const wrist = landmarks.landmarks[hand][0];
     const middleBase = landmarks.landmarks[hand][9];
     const palmCenterY = canvas.height * ((wrist.y + middleBase.y) / 2);
-    const palmCenterX = canvas.width * wrist.x;
+    const palmCenterX = canvas.width - canvas.width * wrist.x;
     return {
       name: this.name,
       points: { palmCenter: { x: palmCenterX, y: palmCenterY } },
@@ -87,7 +87,7 @@ class Pinch extends Gesture {
     const thumbTip = landmarks.landmarks[hand][4];
     const indexTip = landmarks.landmarks[hand][8];
 
-    const pinchPointX = canvas.width * ((thumbTip.x + indexTip.x) / 2);
+    const pinchPointX = canvas.width - canvas.width * ((thumbTip.x + indexTip.x) / 2);
     const pinchPointY = canvas.height * ((thumbTip.y + indexTip.y) / 2);
 
     return {

--- a/hansroslinger/src/app/detection/Gesture.ts
+++ b/hansroslinger/src/app/detection/Gesture.ts
@@ -87,7 +87,8 @@ class Pinch extends Gesture {
     const thumbTip = landmarks.landmarks[hand][4];
     const indexTip = landmarks.landmarks[hand][8];
 
-    const pinchPointX = canvas.width - canvas.width * ((thumbTip.x + indexTip.x) / 2);
+    const pinchPointX =
+      canvas.width - canvas.width * ((thumbTip.x + indexTip.x) / 2);
     const pinchPointY = canvas.height * ((thumbTip.y + indexTip.y) / 2);
 
     return {

--- a/hansroslinger/src/app/preview/CameraFeed.tsx
+++ b/hansroslinger/src/app/preview/CameraFeed.tsx
@@ -35,6 +35,10 @@ const CameraFeed = () => {
                   canvasRef.current,
                 );
                 console.log(payload);
+                const { payloads } = payload;
+                payloads.forEach((gesturePayload) =>
+                  interactionManager.handleGestureInput(gesturePayload)
+              );
                 canvasRenderer(
                   canvasRef.current,
                   videoRef.current,

--- a/hansroslinger/src/app/preview/CameraFeed.tsx
+++ b/hansroslinger/src/app/preview/CameraFeed.tsx
@@ -35,10 +35,6 @@ const CameraFeed = () => {
                   canvasRef.current,
                 );
                 console.log(payload);
-                const { payloads } = payload;
-                payloads.forEach((gesturePayload) =>
-                  interactionManager.handleGestureInput(gesturePayload)
-              );
                 canvasRenderer(
                   canvasRef.current,
                   videoRef.current,

--- a/hansroslinger/src/components/interactions/actions/handleDrag.tsx
+++ b/hansroslinger/src/components/interactions/actions/handleDrag.tsx
@@ -3,7 +3,7 @@ import { useVisualStore } from "store/visualsSlice";
 export const handleDrag = (
   id: string,
   pointer: { x: number; y: number },
-  offset: { x: number; y: number }
+  offset: { x: number; y: number },
 ) => {
   const store = useVisualStore.getState();
   const visual = store.getVisual(id);

--- a/hansroslinger/src/components/interactions/actions/handleDrag.tsx
+++ b/hansroslinger/src/components/interactions/actions/handleDrag.tsx
@@ -1,10 +1,18 @@
 import { useVisualStore } from "store/visualsSlice";
-import { VisualPosition } from "types/application";
 
-export const handleDrag = (id: string, pointer: VisualPosition) => {
+export const handleDrag = (
+  id: string,
+  pointer: { x: number; y: number },
+  offset: { x: number; y: number }
+) => {
   const store = useVisualStore.getState();
   const visual = store.getVisual(id);
   if (!visual) return;
 
-  store.setVisualPosition(id, pointer);
+  const newPosition = {
+    x: pointer.x - offset.x,
+    y: pointer.y - offset.y,
+  };
+
+  store.setVisualPosition(id, newPosition);
 };

--- a/hansroslinger/src/components/interactions/actions/handleHover.tsx
+++ b/hansroslinger/src/components/interactions/actions/handleHover.tsx
@@ -1,9 +1,23 @@
 import { useVisualStore } from "store/visualsSlice";
 
-export const handleHover = (id: string, isHovered: boolean) => {
-  const store = useVisualStore.getState();
-  const visual = store.getVisual(id);
-  if (!visual) return;
+let lastHoveredId: string | null = null;
 
-  store.setVisualHover(id, isHovered);
+export const handleHover = (id: string | null, isHovered: boolean) => {
+  const store = useVisualStore.getState();
+
+  if (lastHoveredId && lastHoveredId !== id) {
+    store.setVisualHover(lastHoveredId, false);
+  }
+
+  if (id && isHovered) {
+    const visual = store.getVisual(id);
+    if (visual) {
+      store.setVisualHover(id, true);
+      lastHoveredId = id;
+    }
+  }
+
+  if (!id) {
+    lastHoveredId = null;
+  }
 };

--- a/hansroslinger/src/components/interactions/interactionManager.tsx
+++ b/hansroslinger/src/components/interactions/interactionManager.tsx
@@ -2,7 +2,7 @@ import { handleDrag } from "./actions/handleDrag";
 import { handleResize } from "./actions/handleResize";
 import { handleHover } from "./actions/handleHover";
 import { useVisualStore } from "store/visualsSlice";
-import { InteractionInput, ActionPayload } from "types/application";
+import { ActionPayload, InteractionInput } from "types/application";
 
 export class InteractionManager {
   private gestureTargetId: string | null = null;
@@ -10,25 +10,6 @@ export class InteractionManager {
 
   private get visuals() {
     return useVisualStore.getState().visuals;
-  }
-
-  handleInput(input: InteractionInput) {
-    const targetId = input.targetId ?? this.findTargetAt(input.position);
-    console.log("[Manager] Input:", input.type, "Target:", targetId);
-
-    if (!targetId) return;
-
-    switch (input.type) {
-      case "move":
-        handleDrag(targetId, input.position, {x:0, y:0});
-        break;
-      case "resize":
-        handleResize(targetId, input.position);
-        break;
-      case "hover":
-        handleHover(targetId, input.isHovered ?? true);
-        break;
-    }
   }
 
   /**
@@ -96,5 +77,25 @@ export class InteractionManager {
       if (withinBounds) return visual.assetId;
     }
     return null;
+  }
+  
+  // ONLY USED FOR MOUSE MOCK
+    handleInput(input: InteractionInput) {
+    const targetId = input.targetId ?? this.findTargetAt(input.position);
+    console.log("[Manager] Input:", input.type, "Target:", targetId);
+
+    if (!targetId) return;
+
+    switch (input.type) {
+      case "move":
+        handleDrag(targetId, input.position, {x:0, y:0});
+        break;
+      case "resize":
+        handleResize(targetId, input.position);
+        break;
+      case "hover":
+        handleHover(targetId, input.isHovered ?? true);
+        break;
+    }
   }
 }

--- a/hansroslinger/src/components/interactions/interactionManager.tsx
+++ b/hansroslinger/src/components/interactions/interactionManager.tsx
@@ -78,9 +78,9 @@ export class InteractionManager {
     }
     return null;
   }
-  
+
   // ONLY USED FOR MOUSE MOCK
-    handleInput(input: InteractionInput) {
+  handleInput(input: InteractionInput) {
     const targetId = input.targetId ?? this.findTargetAt(input.position);
     console.log("[Manager] Input:", input.type, "Target:", targetId);
 
@@ -88,7 +88,7 @@ export class InteractionManager {
 
     switch (input.type) {
       case "move":
-        handleDrag(targetId, input.position, {x:0, y:0});
+        handleDrag(targetId, input.position, { x: 0, y: 0 });
         break;
       case "resize":
         handleResize(targetId, input.position);

--- a/hansroslinger/src/components/interactions/interactionManager.tsx
+++ b/hansroslinger/src/components/interactions/interactionManager.tsx
@@ -3,12 +3,16 @@ import { handleResize } from "./actions/handleResize";
 import { handleHover } from "./actions/handleHover";
 import { useVisualStore } from "store/visualsSlice";
 import { ActionPayload, InteractionInput } from "types/application";
+import { GesturePayload } from "app/detection/Gesture";
 
 /**
  * The InteractionManager routes user input actions (e.g. drag, resize, hover)
  * to the correct handler based on pointer location and interaction type.
  */
 export class InteractionManager {
+  private gestureTargetId: string | null = null;
+  private dragOffset: { x: number; y: number } | null = null;
+
   /**
    * Returns the current list of visuals from the Zustand store.
    * This reflects the latest state of all on-screen visual elements.
@@ -41,18 +45,76 @@ export class InteractionManager {
     // Dispatch to appropriate handler
     switch (input.type) {
       case "move":
-        handleDrag(targetId, input.position);
+        handleDrag(targetId, input.position, {x: 0, y: 0});
         break;
       case "resize":
         handleResize(targetId, input.position);
         break;
       case "hover":
-        if (typeof input.isHovered === "boolean") {
-          handleHover(targetId, input.isHovered);
-        }
+        handleHover(targetId, input.isHovered ?? true);
         break;
     }
   }
+
+  handleGestureInput(payload: GesturePayload) {
+    switch (payload.name) {
+      case "Open_Palm": {
+        const pos = payload.points.palmCenter;
+        console.log(pos);
+        const targetId = this.findTargetAt(pos);
+        if (targetId) handleHover(targetId, true);
+        break;
+      }
+
+      case "Pointing_Up": {
+        const pos = payload.points.indexFingerTip;
+        const targetId = this.findTargetAt(pos);
+        if (targetId) handleHover(targetId, true);
+        break;
+      }
+
+      case "Pinch": {
+        const pos = payload.points.pinchPoint;
+        const targetId = this.findTargetAt(pos);
+        if (!targetId) {
+          // Gesture moved off target → reset
+          this.gestureTargetId = null;
+          this.dragOffset = null;
+          return;
+        }
+
+        const store = useVisualStore.getState();
+        const visual = store.getVisual(targetId);
+        if (!visual) return;
+
+        // If new gesture target, calculate and store offset
+        if (this.gestureTargetId !== targetId) {
+          this.gestureTargetId = targetId;
+          this.dragOffset = {
+            x: pos.x - visual.position.x,
+            y: pos.y - visual.position.y,
+          };
+        }
+
+        // Reuse stored offset for drag
+        handleDrag(targetId, pos, this.dragOffset!);
+        break;
+      }
+
+
+      case "Double_Pinch": {
+        const p1 = payload.points.pinchPoint1;
+        const p2 = payload.points.pinchPoint2;
+        const midpoint = {
+          x: (p1.x + p2.x) / 2,
+          y: (p1.y + p2.y) / 2,
+        };
+        const targetId = this.findTargetAt(midpoint);
+        if (targetId) handleResize(targetId, midpoint);
+        break;
+      }
+    }
+  }  
 
   /**
    * Finds the visual (if any) currently under the given pointer position.


### PR DESCRIPTION
This PR adapts the InteractionManager to support declarative gesture-driven actions via useGestureListener. 

**Key changes:**

- handleAction now interprets gesture payloads and maintains drag offset state
- handleDrag supports  dragging via calculated offsets
- handleHover tracks previously hovered visual but does not yet clear hover on exit
- handleResize is  **not** yet implemented
- handleInput and useMouseMockStream are retained for debugging/testing

Known Issues:

- Dragging can lose track of target visual during rapid gesture movement
- Hover state is not properly cleared when an open palm moves away
- General perfomance limits