### PR TITLE
feat(camera): Add a toggled Annotation Feature (draw/erase) to CameraFeed Preview

### DIFF
--- a/hansroslinger/src/app/preview/AnnotationLayer.tsx
+++ b/hansroslinger/src/app/preview/AnnotationLayer.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import React, { useEffect, useRef, useState } from "react";
+
+type AnnotationLayerProps = {
+  /** Element to align/sync canvas size with video element. */
+  targetRef: React.RefObject<HTMLElement | null>;
+  /** Start with annotation enabled. */
+  defaultEnabled?: boolean;
+  /** className for the wrapper. */
+  className?: string;
+  /** z-index for the canvas/toolbar stack. */
+  zIndex?: number;
+};
+
+const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
+  targetRef,
+  defaultEnabled = false,
+  className = "",
+  zIndex = 50,
+}) => {
+  // Canvas & drawing refs
+  const annotationCanvasRef = useRef<HTMLCanvasElement>(null);
+  const isDrawingRef = useRef(false);
+  const lastPosRef = useRef<{ x: number; y: number } | null>(null);
+
+  // UI state
+  const [enabled, setEnabled] = useState(defaultEnabled);
+  const [tool, setTool] = useState<"draw" | "erase">("draw");
+  const [strokeWidth, setStrokeWidth] = useState(4);
+  const [strokeColor, setStrokeColor] = useState("#00ff88");
+
+  // Size canvas to match target 
+  const sizeToTarget = () => {
+    const target = targetRef.current;
+    const canvas = annotationCanvasRef.current;
+    if (!target || !canvas) return;
+
+    const rect = target.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+
+    // CSS box
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+
+    // Backing store
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
+
+    const ctx = canvas.getContext("2d");
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  };
+
+  const clearAnnotations = () => {
+    const c = annotationCanvasRef.current;
+    const ctx = c?.getContext("2d");
+    if (c && ctx) ctx.clearRect(0, 0, c.width, c.height);
+  };
+
+  const getRelativePos = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    const canvas = annotationCanvasRef.current!;
+    const rect = canvas.getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!enabled) return;
+    const canvas = annotationCanvasRef.current!;
+    canvas.setPointerCapture(e.pointerId);
+    isDrawingRef.current = true;
+    lastPosRef.current = getRelativePos(e);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!enabled || !isDrawingRef.current) return;
+    const canvas = annotationCanvasRef.current!;
+    const ctx = canvas.getContext("2d")!;
+    const pos = getRelativePos(e);
+    const last = lastPosRef.current!;
+
+    const pressure = e.pressure && e.pressure > 0 ? e.pressure : 1;
+
+    ctx.lineJoin = "round";
+    ctx.lineCap = "round";
+    ctx.lineWidth = Math.max(1, strokeWidth * pressure);
+    ctx.globalCompositeOperation = tool === "erase" ? "destination-out" : "source-over";
+    if (tool === "draw") ctx.strokeStyle = strokeColor;
+
+    ctx.beginPath();
+    ctx.moveTo(last.x, last.y);
+    ctx.lineTo(pos.x, pos.y);
+    ctx.stroke();
+
+    lastPosRef.current = pos;
+  };
+
+  const handlePointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
+    if (!enabled) return;
+    const canvas = annotationCanvasRef.current!;
+    canvas.releasePointerCapture(e.pointerId);
+    isDrawingRef.current = false;
+    lastPosRef.current = null;
+  };
+
+  // Size once after mount & whenever window resizes
+  useEffect(() => {
+    const rafId = requestAnimationFrame(sizeToTarget);
+    const onResize = () => sizeToTarget();
+    window.addEventListener("resize", onResize);
+    return () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener("resize", onResize);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Re-size when the target element size changes 
+  useEffect(() => {
+    if (!targetRef.current) return;
+    const ro = new ResizeObserver(() => sizeToTarget());
+    ro.observe(targetRef.current);
+    return () => ro.disconnect();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [targetRef.current]);
+
+  return (
+    <>
+      {/* Annotation canvas */}
+      <canvas
+        ref={annotationCanvasRef}
+        className={`absolute inset-0 ${className}`}
+        style={{
+          zIndex,
+          pointerEvents: enabled ? "auto" : "none",
+          touchAction: "none",
+        }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+      />
+
+      {/* Toolbar */}
+      <div
+        className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 bg-black/60 text-white rounded-2xl px-3 py-2 backdrop-blur"
+        style={{ zIndex: zIndex + 1 }}
+      >
+        <button
+          onClick={() => setEnabled((v) => !v)}
+          className={`px-3 py-1 rounded-xl ${enabled ? "bg-white text-black" : "bg-white/10"}`}
+          aria-pressed={enabled}
+          title="Toggle annotations"
+        >
+          {enabled ? "Annotation: On" : "Annotation: Off"}
+        </button>
+
+        <div className={`flex items-center gap-2 ${enabled ? "opacity-100" : "opacity-40 pointer-events-none"}`}>
+          <button
+            onClick={() => setTool("draw")}
+            className={`px-2 py-1 rounded ${tool === "draw" ? "bg-white text-black" : "bg-white/10"}`}
+            aria-pressed={tool === "draw"}
+            title="Draw"
+          >
+            ✏️
+          </button>
+          <button
+            onClick={() => setTool("erase")}
+            className={`px-2 py-1 rounded ${tool === "erase" ? "bg-white text-black" : "bg-white/10"}`}
+            aria-pressed={tool === "erase"}
+            title="Erase"
+          >
+            🧽
+          </button>
+
+          <label className="flex items-center gap-2 text-xs">
+            <span>Color</span>
+            <input
+              type="color"
+              value={strokeColor}
+              onChange={(e) => setStrokeColor(e.target.value)}
+              className="h-8 w-8 rounded overflow-hidden border border-white/20"
+            />
+          </label>
+
+          <label className="flex items-center gap-2 text-xs">
+            <span>Size</span>
+            <input
+              type="range"
+              min={2}
+              max={24}
+              step={1}
+              value={strokeWidth}
+              onChange={(e) => setStrokeWidth(Number(e.target.value))}
+              className="w-24"
+            />
+          </label>
+
+          <button onClick={clearAnnotations} className="px-2 py-1 rounded bg-white/10" title="Clear">
+            Clear
+          </button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default AnnotationLayer;

--- a/hansroslinger/src/app/preview/CameraFeed.tsx
+++ b/hansroslinger/src/app/preview/CameraFeed.tsx
@@ -26,6 +26,39 @@
     const [strokeWidth, setStrokeWidth] = useState(4);
     const [strokeColor, setStrokeColor] = useState("#00ff88");
 
+    // --- sizing helper (HiDPI-safe) ---
+  const sizeCanvasesToVideo = () => {
+    const video = videoRef.current;
+    if (!video) return;
+
+    const rect = video.getBoundingClientRect();
+    const dpr = window.devicePixelRatio || 1;
+
+    const apply = (c?: HTMLCanvasElement | null) => {
+      if (!c) return;
+      // CSS size to match rendered video
+      c.style.width = `${rect.width}px`;
+      c.style.height = `${rect.height}px`;
+      // Backing store scaled for HiDPI
+      c.width = Math.round(rect.width * dpr);
+      c.height = Math.round(rect.height * dpr);
+      const ctx = c.getContext("2d");
+      if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+
+    apply(canvasRef.current);
+    apply(annotationCanvasRef.current);
+  };
+
+  // --- annotation helpers ---
+  const clearAnnotations = () => {
+    const c = annotationCanvasRef.current;
+    const ctx = c?.getContext("2d");
+    if (c && ctx) ctx.clearRect(0, 0, c.width, c.height);
+  };
+
+  
+
     useEffect(() => {
       const startCamera = async () => {
         try {

--- a/hansroslinger/src/app/preview/CameraFeed.tsx
+++ b/hansroslinger/src/app/preview/CameraFeed.tsx
@@ -4,112 +4,40 @@ import { useEffect, useRef, useState } from "react";
 import { HandRecogniser } from "app/detection/handRecognition";
 import { canvasRenderer } from "app/detection/canvasRenderer";
 import { useGestureStore } from "store/gestureSlice";
+import AnnotationLayer from "./AnnotationLayer";
 
 /**
  * CameraFeed component handles accessing the user's camera and microphone.
- * It shows a mirrored live video feed with an error handling message if access fails.
- * Adds an annotation layer (draw/erase) on top of the camera feed.
+ * Shows a mirrored live video feed with landmarks overlay.
+ * Annotation layer feature (draw/erase) on top of the camera feed.
  */
 const CameraFeed = () => {
-  // video canvas refs/state 
   const videoRef = useRef<HTMLVideoElement>(null);
-  const canvasRef = useRef<HTMLCanvasElement>(null); // existing overlay canvas for landmarks/visuals
+  const canvasRef = useRef<HTMLCanvasElement>(null);
   const [cameraError, setCameraError] = useState(false);
   const setGesturePayload = useGestureStore((state) => state.setGesturePayloads);
 
   // keep track of the interval so we can clear it on unmount
   const intervalRef = useRef<number | null>(null);
 
-  // annotation refs/state 
-  const annotationCanvasRef = useRef<HTMLCanvasElement>(null);
-  const isDrawingRef = useRef(false);
-  const lastPosRef = useRef<{ x: number; y: number } | null>(null);
-
-  const [annotationOn, setAnnotationOn] = useState(false);
-  const [tool, setTool] = useState<"draw" | "erase">("draw");
-  const [strokeWidth, setStrokeWidth] = useState(4);
-  const [strokeColor, setStrokeColor] = useState("#00ff88");
-
-  // sizing helper (HiDPI-safe) 
-  const sizeCanvasesToVideo = () => {
+  // Size overlay canvas to match the rendered video (HiDPI-safe)
+  const sizeOverlayToVideo = () => {
     const video = videoRef.current;
-    if (!video) return;
+    const canvas = canvasRef.current;
+    if (!video || !canvas) return;
 
     const rect = video.getBoundingClientRect();
     const dpr = window.devicePixelRatio || 1;
 
-    const apply = (c?: HTMLCanvasElement | null) => {
-      if (!c) return;
-      // CSS size to match rendered video
-      c.style.width = `${rect.width}px`;
-      c.style.height = `${rect.height}px`;
-      // Backing store scaled for HiDPI
-      c.width = Math.round(rect.width * dpr);
-      c.height = Math.round(rect.height * dpr);
-      const ctx = c.getContext("2d");
-      if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
-    };
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    canvas.width = Math.round(rect.width * dpr);
+    canvas.height = Math.round(rect.height * dpr);
 
-    apply(canvasRef.current);
-    apply(annotationCanvasRef.current);
+    const ctx = canvas.getContext("2d");
+    if (ctx) ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   };
 
-  // annotation helpers 
-  const clearAnnotations = () => {
-    const c = annotationCanvasRef.current;
-    const ctx = c?.getContext("2d");
-    if (c && ctx) ctx.clearRect(0, 0, c.width, c.height);
-  };
-
-  const getRelativePos = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    const canvas = annotationCanvasRef.current!;
-    const rect = canvas.getBoundingClientRect();
-    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
-  };
-
-  const handlePointerDown = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!annotationOn) return;
-    const canvas = annotationCanvasRef.current!;
-    canvas.setPointerCapture(e.pointerId);
-    isDrawingRef.current = true;
-    lastPosRef.current = getRelativePos(e);
-  };
-
-  const handlePointerMove = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!annotationOn || !isDrawingRef.current) return;
-
-    const canvas = annotationCanvasRef.current!;
-    const ctx = canvas.getContext("2d")!;
-    const pos = getRelativePos(e);
-    const last = lastPosRef.current!;
-
-    // pen pressure option support
-    const pressure = e.pressure && e.pressure > 0 ? e.pressure : 1;
-
-    ctx.lineJoin = "round";
-    ctx.lineCap = "round";
-    ctx.lineWidth = Math.max(1, strokeWidth * pressure);
-    ctx.globalCompositeOperation =
-      tool === "erase" ? "destination-out" : "source-over";
-    if (tool === "draw") ctx.strokeStyle = strokeColor;
-
-    ctx.beginPath();
-    ctx.moveTo(last.x, last.y);
-    ctx.lineTo(pos.x, pos.y);
-    ctx.stroke();
-
-    lastPosRef.current = pos;
-  };
-
-  const handlePointerUp = (e: React.PointerEvent<HTMLCanvasElement>) => {
-    if (!annotationOn) return;
-    const canvas = annotationCanvasRef.current!;
-    canvas.releasePointerCapture(e.pointerId);
-    isDrawingRef.current = false;
-    lastPosRef.current = null;
-  };
-
-  // camera detection loop 
   useEffect(() => {
     const startCamera = async () => {
       try {
@@ -121,12 +49,11 @@ const CameraFeed = () => {
         if (videoRef.current && canvasRef.current) {
           videoRef.current.srcObject = stream;
 
-          // size canvases once the video lays out
-          requestAnimationFrame(sizeCanvasesToVideo);
-          // keep in sync on window resize
-          window.addEventListener("resize", sizeCanvasesToVideo);
+          // size overlay once laid out and on resize
+          requestAnimationFrame(sizeOverlayToVideo);
+          window.addEventListener("resize", sizeOverlayToVideo);
 
-          // detection/render loop (100ms)
+          // original detection/render loop
           intervalRef.current = window.setInterval(async () => {
             if (videoRef.current && canvasRef.current) {
               if (
@@ -158,30 +85,23 @@ const CameraFeed = () => {
     startCamera();
 
     const videoElement = videoRef.current;
-
     return () => {
-      // remove resize listener
-      window.removeEventListener("resize", sizeCanvasesToVideo);
-
-      // clear detection interval
+      window.removeEventListener("resize", sizeOverlayToVideo);
       if (intervalRef.current != null) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;
       }
-
-      // stop camera tracks
       if (videoElement && videoElement.srcObject) {
         const tracks = (videoElement.srcObject as MediaStream).getTracks();
         tracks.forEach((track) => track.stop());
       }
     };
-    //comment code below will ignore the warning from eslint
-   // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   return (
     <div className="relative w-full h-full">
-      {/* Show video if no error */}
+      {/* Video layer (mirrored) */}
       {!cameraError && (
         <video
           id="cameraFeed"
@@ -193,97 +113,16 @@ const CameraFeed = () => {
         />
       )}
 
-      {/* landmark overlay canvas visual */}
+      {/* Existing overlay canvas for landmarks/visuals */}
       <canvas
         ref={canvasRef}
         className="absolute top-0 left-0 w-full h-full pointer-events-none"
       />
 
-      {/* Annotation canvas (on top). Pointer events only when enabled */}
-      <canvas
-        ref={annotationCanvasRef}
-        className={`absolute top-0 left-0 w-full h-full z-50 ${
-          annotationOn ? "pointer-events-auto" : "pointer-events-none"
-        }`}
-        onPointerDown={handlePointerDown}
-        onPointerMove={handlePointerMove}
-        onPointerUp={handlePointerUp}
-        onPointerCancel={handlePointerUp}
-      />
+      {/* Annotation layer */}
+      <AnnotationLayer targetRef={videoRef} />
 
-      {/* Annotation toolbar */}
-      <div className="absolute bottom-4 left-1/2 -translate-x-1/2 z-[60] flex items-center gap-2 bg-black/60 text-white rounded-2xl px-3 py-2 backdrop-blur">
-        <button
-          onClick={() => setAnnotationOn((v) => !v)}
-          className={`px-3 py-1 rounded-xl ${
-            annotationOn ? "bg-white text-black" : "bg-white/10"
-          }`}
-          aria-pressed={annotationOn}
-          title="Toggle annotations"
-        >
-          {annotationOn ? "Annotation: On" : "Annotation: Off"}
-        </button>
-
-        <div
-          className={`flex items-center gap-2 ${
-            annotationOn ? "opacity-100" : "opacity-40 pointer-events-none"
-          }`}
-        >
-          <button
-            onClick={() => setTool("draw")}
-            className={`px-2 py-1 rounded ${
-              tool === "draw" ? "bg-white text-black" : "bg-white/10"
-            }`}
-            aria-pressed={tool === "draw"}
-            title="Draw"
-          >
-            ✏️
-          </button>
-          <button
-            onClick={() => setTool("erase")}
-            className={`px-2 py-1 rounded ${
-              tool === "erase" ? "bg-white text-black" : "bg-white/10"
-            }`}
-            aria-pressed={tool === "erase"}
-            title="Erase"
-          >
-            🧽
-          </button>
-
-          <label className="flex items-center gap-2 text-xs">
-            <span>Color</span>
-            <input
-              type="color"
-              value={strokeColor}
-              onChange={(e) => setStrokeColor(e.target.value)}
-              className="h-8 w-8 rounded overflow-hidden border border-white/20"
-            />
-          </label>
-
-          <label className="flex items-center gap-2 text-xs">
-            <span>Size</span>
-            <input
-              type="range"
-              min={2}
-              max={24}
-              step={1}
-              value={strokeWidth}
-              onChange={(e) => setStrokeWidth(Number(e.target.value))}
-              className="w-24"
-            />
-          </label>
-
-          <button
-            onClick={clearAnnotations}
-            className="px-2 py-1 rounded bg-white/10"
-            title="Clear"
-          >
-            Clear
-          </button>
-        </div>
-      </div>
-
-      {/* Show error message if camera is not available */}
+      {/* Error banner */}
       {cameraError && (
         <div className="absolute inset-0 flex items-center justify-center bg-black bg-opacity-70">
           <div className="text-center px-4 text-white text-lg font-semibold">


### PR DESCRIPTION
## <type>(<scope>): <brief description> ([Link](Paste Notion link here))

<!--
Example: feat(UI): Add gesture-based slide navigation ([Link](https://www.notion.so/your-task-url))
Type options:
- feat: A new feature
- hotfix: A bug fix
- docs: Documentation changes
- style: Code style changes (formatting, missing semicolons, etc.)
- refactor: Code refactoring (non-functional changes)
- test: Adding or modifying tests
- chore: Routine tasks or updates like dependency upgrades
-->

## 📝 Description
Introduces an annotation feature on the camera preview screen. Users can toggle annotations on/off and draw or erase notes directly over the live camera feed by using the mouse click.


## ✅ Checklist

<!--
To check, replace space between [] with x, i.e. [x]
-->

### Required

- [x] New component `AnnotationLayer`:
- Pure Canvas 2D + Pointer Events (no new libraries)
- Tools: Draw / Erase, color picker, stroke size
- Clear button to wipe annotations
- HiDPI-safe sizing 
- Uses ResizeObserver + window.resize to stay aligned with the video
- Pointer input is captured only when enabled (pointer-events: auto/none)

- [x] `CameraFeed` cleanup:
- Import and mounts `<AnnotationLayer targetRef={videoRef} />`
- Code and documentation cleanup 


### Note
- The annotation only works with mouse click as of for now.
- The Image objects can be still moved when the annotation feature is toggled on.

## 🖼️ Screenshots / Recordings (For UI/UX PRs)
- annotation UI when toggled off
<img width="2540" height="1292" alt="image" src="https://github.com/user-attachments/assets/73b830cf-d083-4009-aabc-f319d1c8f312" />

- annotation UI when toggled on
<img width="2553" height="1299" alt="image" src="https://github.com/user-attachments/assets/dfd9287d-6054-44ba-8779-118c914e21ae" />


