### PR TITLE
feat(canvas): add Clear All button to remove all visuals

### DIFF
--- a/hansroslinger/src/components/ClearButton.tsx
+++ b/hansroslinger/src/components/ClearButton.tsx
@@ -1,0 +1,30 @@
+"use client";
+import React from "react";
+import { useVisualStore } from "store/visualsSlice";
+
+const ClearButton = () => {
+  const clearVisual = useVisualStore((state) => state.clearVisual);
+
+  return (
+    <button
+      onClick={clearVisual}
+      style={{
+        position: "fixed",
+        bottom: 20,
+        right: 20,
+        padding: "10px 16px",
+        backgroundColor: "#ef4444",
+        color: "white",
+        border: "none",
+        borderRadius: "6px",
+        cursor: "pointer",
+        fontSize: "14px",
+        zIndex: 9999,
+      }}
+    >
+      Clear All
+    </button>
+  );
+};
+
+export default ClearButton;

--- a/hansroslinger/src/components/KonvaOverlay.tsx
+++ b/hansroslinger/src/components/KonvaOverlay.tsx
@@ -10,6 +10,8 @@ import { InteractionManager } from "./interactions/interactionManager";
 import { useMouseMockStream } from "./interactions/useMouseMockStream";
 import { useGestureListener } from "./interactions/useGestureListener";
 
+import ClearButton from "./ClearButton";
+
 const CanvasOverlay = () => {
   const visuals = useVisualStore((state) => state.visuals);
 
@@ -56,6 +58,8 @@ const CanvasOverlay = () => {
             }
             return null;
           })}
+
+          <ClearButton />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
This PR introduces a "Clear All" button fixed at the bottom-right corner of the interface.  
When clicked, it removes all visuals from the canvas by invoking the existing `clearVisual` method in the visual store.  

---

## Checklist
- [x] Feature branch created from `develop`.
- [x] Feature branch rebased with latest `develop`.
- [x] All tests passed locally.
- [x] Linting completed with no errors.
- [x] Screenshot of working feature attached.

---

## Screenshots
**Before:**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/03603fbc-20c6-4c5f-a86e-047af10f6d68" />

**After:**
<img width="1920" height="1032" alt="image" src="https://github.com/user-attachments/assets/2946d7aa-ecae-44f6-b97e-edda48396428" />



