### PR TITLE
feat(paint): Implement Mode Toggle Button and Core Functionality

### DIFF
--- a/hansroslinger/src/app/preview/AnnotationLayer.tsx
+++ b/hansroslinger/src/app/preview/AnnotationLayer.tsx
@@ -156,7 +156,9 @@ const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
           className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 bg-black/60 text-white rounded-2xl px-3 py-2 backdrop-blur"
           style={{ zIndex: zIndex + 1 }}
         >
-          <div className={`flex items-center gap-2 ${enabled ? "opacity-100" : "opacity-40 pointer-events-none"}`}>
+          <div
+            className={`flex items-center gap-2 ${enabled ? "opacity-100" : "opacity-40 pointer-events-none"}`}
+          >
             <button
               onClick={() => setTool("draw")}
               className={`px-2 py-1 rounded ${tool === "draw" ? "bg-white text-black" : "bg-white/10"}`}
@@ -197,7 +199,11 @@ const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
               />
             </label>
 
-            <button onClick={clearAnnotations} className="px-2 py-1 rounded bg-white/10" title="Clear">
+            <button
+              onClick={clearAnnotations}
+              className="px-2 py-1 rounded bg-white/10"
+              title="Clear"
+            >
               Clear
             </button>
           </div>

--- a/hansroslinger/src/app/preview/AnnotationLayer.tsx
+++ b/hansroslinger/src/app/preview/AnnotationLayer.tsx
@@ -7,8 +7,6 @@ import ModeToggle from "@/components/ModeToggle";
 type AnnotationLayerProps = {
   /** Element to align/sync canvas size with video element. */
   targetRef: React.RefObject<HTMLElement | null>;
-  /** Start with annotation enabled. */
-  defaultEnabled?: boolean;
   /** className for the wrapper. */
   className?: string;
   /** z-index for the canvas/toolbar stack. */
@@ -17,7 +15,6 @@ type AnnotationLayerProps = {
 
 const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
   targetRef,
-  defaultEnabled = false,
   className = "",
   zIndex = 50,
 }) => {

--- a/hansroslinger/src/app/preview/AnnotationLayer.tsx
+++ b/hansroslinger/src/app/preview/AnnotationLayer.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
+import { useModeStore } from "store/modeSlice";
+import ModeToggle from "@/components/ModeToggle";
 
 type AnnotationLayerProps = {
   /** Element to align/sync canvas size with video element. */
@@ -25,7 +27,8 @@ const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
   const lastPosRef = useRef<{ x: number; y: number } | null>(null);
 
   // UI state
-  const [enabled, setEnabled] = useState(defaultEnabled);
+  const mode = useModeStore((s) => s.mode);
+  const enabled = mode === "paint";
   const [tool, setTool] = useState<"draw" | "erase">("draw");
   const [strokeWidth, setStrokeWidth] = useState(4);
   const [strokeColor, setStrokeColor] = useState("#00ff88");
@@ -125,7 +128,7 @@ const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
   }, [targetRef.current]);
 
   return (
-    <>
+    <div className="absolute inset-0" style={{ zIndex }}>
       {/* Annotation canvas */}
       <canvas
         ref={annotationCanvasRef}
@@ -140,74 +143,67 @@ const AnnotationLayer: React.FC<AnnotationLayerProps> = ({
         onPointerUp={handlePointerUp}
         onPointerCancel={handlePointerUp}
       />
-
-      {/* Toolbar */}
+      {/* Paint mode button */}
       <div
-        className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 bg-black/60 text-white rounded-2xl px-3 py-2 backdrop-blur"
-        style={{ zIndex: zIndex + 1 }}
+        className="absolute top-3 left-3 pointer-events-auto"
+        style={{ zIndex: zIndex + 2 }}
       >
-        <button
-          onClick={() => setEnabled((v) => !v)}
-          className={`px-3 py-1 rounded-xl ${enabled ? "bg-white text-black" : "bg-white/10"}`}
-          aria-pressed={enabled}
-          title="Toggle annotations"
-        >
-          {enabled ? "Annotation: On" : "Annotation: Off"}
-        </button>
-
-        <div
-          className={`flex items-center gap-2 ${enabled ? "opacity-100" : "opacity-40 pointer-events-none"}`}
-        >
-          <button
-            onClick={() => setTool("draw")}
-            className={`px-2 py-1 rounded ${tool === "draw" ? "bg-white text-black" : "bg-white/10"}`}
-            aria-pressed={tool === "draw"}
-            title="Draw"
-          >
-            ✏️
-          </button>
-          <button
-            onClick={() => setTool("erase")}
-            className={`px-2 py-1 rounded ${tool === "erase" ? "bg-white text-black" : "bg-white/10"}`}
-            aria-pressed={tool === "erase"}
-            title="Erase"
-          >
-            🧽
-          </button>
-
-          <label className="flex items-center gap-2 text-xs">
-            <span>Color</span>
-            <input
-              type="color"
-              value={strokeColor}
-              onChange={(e) => setStrokeColor(e.target.value)}
-              className="h-8 w-8 rounded overflow-hidden border border-white/20"
-            />
-          </label>
-
-          <label className="flex items-center gap-2 text-xs">
-            <span>Size</span>
-            <input
-              type="range"
-              min={2}
-              max={24}
-              step={1}
-              value={strokeWidth}
-              onChange={(e) => setStrokeWidth(Number(e.target.value))}
-              className="w-24"
-            />
-          </label>
-
-          <button
-            onClick={clearAnnotations}
-            className="px-2 py-1 rounded bg-white/10"
-            title="Clear"
-          >
-            Clear
-          </button>
-        </div>
+        <ModeToggle />
       </div>
-    </>
+      {/* Conditionally rendered toolbar */}
+      {enabled && (
+        <div
+          className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 bg-black/60 text-white rounded-2xl px-3 py-2 backdrop-blur"
+          style={{ zIndex: zIndex + 1 }}
+        >
+          <div className={`flex items-center gap-2 ${enabled ? "opacity-100" : "opacity-40 pointer-events-none"}`}>
+            <button
+              onClick={() => setTool("draw")}
+              className={`px-2 py-1 rounded ${tool === "draw" ? "bg-white text-black" : "bg-white/10"}`}
+              aria-pressed={tool === "draw"}
+              title="Draw"
+            >
+              ✏️
+            </button>
+            <button
+              onClick={() => setTool("erase")}
+              className={`px-2 py-1 rounded ${tool === "erase" ? "bg-white text-black" : "bg-white/10"}`}
+              aria-pressed={tool === "erase"}
+              title="Erase"
+            >
+              🧽
+            </button>
+
+            <label className="flex items-center gap-2 text-xs">
+              <span>Color</span>
+              <input
+                type="color"
+                value={strokeColor}
+                onChange={(e) => setStrokeColor(e.target.value)}
+                className="h-8 w-8 rounded overflow-hidden border border-white/20"
+              />
+            </label>
+
+            <label className="flex items-center gap-2 text-xs">
+              <span>Size</span>
+              <input
+                type="range"
+                min={2}
+                max={24}
+                step={1}
+                value={strokeWidth}
+                onChange={(e) => setStrokeWidth(Number(e.target.value))}
+                className="w-24"
+              />
+            </label>
+
+            <button onClick={clearAnnotations} className="px-2 py-1 rounded bg-white/10" title="Clear">
+              Clear
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
   );
 };
 

--- a/hansroslinger/src/components/ModeToggle.tsx
+++ b/hansroslinger/src/components/ModeToggle.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import { useModeStore } from "store/modeSlice";
+
+export default function ModeToggle() {
+  const mode = useModeStore((s) => s.mode);
+  const toggle = useModeStore((s) => s.toggleMode);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() === "p") {
+        e.preventDefault();
+        toggle();
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [toggle]);
+
+  return (
+    <button
+      onClick={toggle}
+      className="fixed bottom-4 right-4 z-[9999] rounded-2xl px-4 py-2 shadow bg-black/80 text-white"
+      aria-pressed={mode === "paint"}
+      aria-label={`Switch to ${mode === "paint" ? "Interact" : "Paint"} mode (P)`}
+      title={`Press P — ${mode === "paint" ? "Interact" : "Paint"} mode`}
+    >
+      {mode === "paint" ? "Paint ✏️" : "Interact 🖐️"}
+    </button>
+  );
+}

--- a/hansroslinger/src/components/ModeToggle.tsx
+++ b/hansroslinger/src/components/ModeToggle.tsx
@@ -21,7 +21,7 @@ export default function ModeToggle() {
   return (
     <button
       onClick={toggle}
-      className="fixed bottom-4 right-4 z-[9999] rounded-2xl px-4 py-2 shadow bg-black/80 text-white"
+      className="z-[9999] rounded-2xl px-4 py-2 shadow bg-black/80 text-white"
       aria-pressed={mode === "paint"}
       aria-label={`Switch to ${mode === "paint" ? "Interact" : "Paint"} mode (P)`}
       title={`Press P — ${mode === "paint" ? "Interact" : "Paint"} mode`}

--- a/hansroslinger/src/components/interactions/useGestureListener.tsx
+++ b/hansroslinger/src/components/interactions/useGestureListener.tsx
@@ -3,7 +3,7 @@ import { gestureToActionMap } from "./gestureMappings";
 import { InteractionManager } from "./interactionManager";
 import { useGestureStore } from "store/gestureSlice";
 import { HAND_IDS } from "constants/application";
-import { useModeStore } from "store/modeSlice"; 
+import { useModeStore } from "store/modeSlice";
 
 export const useGestureListener = (interactionManager: InteractionManager) => {
   const gesturePayloads = useGestureStore((state) => state.gesturePayloads);
@@ -21,7 +21,7 @@ export const useGestureListener = (interactionManager: InteractionManager) => {
     // (Later we will route these to the paint pipeline instead.)
     if (mode === "paint") return;
 
-    // Interact mode: 
+    // Interact mode:
     gesturePayloads.forEach((payload) => {
       const action = gestureToActionMap[payload.name];
       if (action) {

--- a/hansroslinger/src/components/interactions/useGestureListener.tsx
+++ b/hansroslinger/src/components/interactions/useGestureListener.tsx
@@ -3,9 +3,11 @@ import { gestureToActionMap } from "./gestureMappings";
 import { InteractionManager } from "./interactionManager";
 import { useGestureStore } from "store/gestureSlice";
 import { HAND_IDS } from "constants/application";
+import { useModeStore } from "store/modeSlice"; 
 
 export const useGestureListener = (interactionManager: InteractionManager) => {
   const gesturePayloads = useGestureStore((state) => state.gesturePayloads);
+  const mode = useModeStore((s) => s.mode);
 
   useEffect(() => {
     if (!gesturePayloads) return;
@@ -15,6 +17,11 @@ export const useGestureListener = (interactionManager: InteractionManager) => {
       interactionManager.handleClear();
     }
 
+    // In Paint mode we *do not* forward gestures to the InteractionManager.
+    // (Later we will route these to the paint pipeline instead.)
+    if (mode === "paint") return;
+
+    // Interact mode: 
     gesturePayloads.forEach((payload) => {
       const action = gestureToActionMap[payload.name];
       if (action) {
@@ -37,7 +44,7 @@ export const useGestureListener = (interactionManager: InteractionManager) => {
         interactionManager.clearTargetForHand(handId);
       }
     });
-  }, [gesturePayloads, interactionManager]);
+  }, [gesturePayloads, interactionManager, mode]);
 
   return null;
 };

--- a/hansroslinger/src/store/modeSlice.ts
+++ b/hansroslinger/src/store/modeSlice.ts
@@ -1,0 +1,16 @@
+// store/modeSlice.ts
+import { create } from "zustand";
+
+export type UIMode = "interact" | "paint";
+
+type ModeState = {
+  mode: UIMode;
+  setMode: (m: UIMode) => void;
+  toggleMode: () => void;
+};
+
+export const useModeStore = create<ModeState>((set, get) => ({
+  mode: "interact",
+  setMode: (m) => set({ mode: m }),
+  toggleMode: () => set({ mode: get().mode === "interact" ? "paint" : "interact" }),
+}));

--- a/hansroslinger/src/store/modeSlice.ts
+++ b/hansroslinger/src/store/modeSlice.ts
@@ -12,5 +12,6 @@ type ModeState = {
 export const useModeStore = create<ModeState>((set, get) => ({
   mode: "interact",
   setMode: (m) => set({ mode: m }),
-  toggleMode: () => set({ mode: get().mode === "interact" ? "paint" : "interact" }),
+  toggleMode: () =>
+    set({ mode: get().mode === "interact" ? "paint" : "interact" }),
 }));


### PR DESCRIPTION
### 📝 **Description**
This PR introduces the Paint Mode toggle feature.
- Adds a toggle button that lets users switch between Interact Mode (move/resize/zoom images) and Paint Mode (freeze images, enable drawing/erasing on the canvas).
- Paint Mode includes a bottom toolbar for tools (draw/erase, color, size, clear).
- Toggle button is positioned top-left of the preview area for visibility.

Note: Still need to make the Paint Mode toggle itself accessible via hand gestures.

### ✅ **Checklist**
Required

- [x] I have rebased my branch
- [x] I have verified existing tests still pass
- [x] I have run linters and code formatters

### 🖼️ **Screenshots / Recordings (For UI/UX PRs)**
**BEFORE**
_Toolbar is always present even in paint mode, PNGs and JSONs can still be interacted with in paint mode_
<img width="3825" height="1800" alt="before" src="https://github.com/user-attachments/assets/4389b35f-6b65-4822-9d8b-4eb6ccdb6b50" />

**AFTER**
_Gestures do not affect interaction canvas while in paint mode, toolbar appears only in paint mode_
<img width="3830" height="1807" alt="after1" src="https://github.com/user-attachments/assets/7a994c63-96f8-4225-87b7-25f1069bc434" />
<img width="3840" height="1805" alt="after2" src="https://github.com/user-attachments/assets/4376f2ef-c7de-4c15-9398-25863c0c7044" />
