### PR TITLE
hotfix(interaction): Fixed flipped and wrong trigger for vegalite interaction

### DIFF
--- a/hansroslinger/package.json
+++ b/hansroslinger/package.json
@@ -24,6 +24,7 @@
     "aws-sdk": "^2.1692.0",
     "aws4": "^1.13.2",
     "canvas": "^3.0.0-rc3",
+    "dotenv": "^17.2.2",
     "fingerpose": "^0.1.0",
     "formidable": "^3.5.4",
     "konva": "^9.3.20",

--- a/hansroslinger/src/app/detection/Gesture.ts
+++ b/hansroslinger/src/app/detection/Gesture.ts
@@ -75,7 +75,7 @@ class PointUp extends Gesture {
   ) {
     const indexFingerTip = landmarks.landmarks[hand][8];
     const indexFingerY = canvas.height * indexFingerTip.y;
-    const indexFingerX = canvas.width * indexFingerTip.x;
+    const indexFingerX = canvas.width - canvas.width * indexFingerTip.x;
 
     return {
       id: landmarks.handedness[hand][0].displayName.toLocaleLowerCase(),

--- a/hansroslinger/src/app/preview/CameraFeed.tsx
+++ b/hansroslinger/src/app/preview/CameraFeed.tsx
@@ -5,6 +5,7 @@ import { HandRecogniser } from "app/detection/handRecognition";
 import { canvasRenderer } from "app/detection/canvasRenderer";
 import { useGestureStore } from "store/gestureSlice";
 import AnnotationLayer from "./AnnotationLayer";
+import { useCanvasStore } from "store/canvasSlice";
 
 /**
  * CameraFeed component handles accessing the user's camera and microphone.
@@ -18,6 +19,13 @@ const CameraFeed = () => {
   const setGesturePayload = useGestureStore(
     (state) => state.setGesturePayloads,
   );
+
+  const setCanvasEl = useCanvasStore((s) => s.setCanvasEl);
+
+  useEffect(() => {
+    setCanvasEl(canvasRef.current);
+    return () => setCanvasEl(null);
+  }, [setCanvasEl]);
 
   // keep track of the interval so we can clear it on unmount
   const intervalRef = useRef<number | null>(null);

--- a/hansroslinger/src/components/GraphDesigner.tsx
+++ b/hansroslinger/src/components/GraphDesigner.tsx
@@ -1,4 +1,4 @@
-"use client"
+"use client";
 
 /**
  * Simple function that reads a JSON file and extracts a specific property
@@ -8,11 +8,11 @@
  */
 export async function GraphDesigner(
   jsonData: object,
-  targetProperty: string
+  targetProperty: string,
 ): Promise<object | null> {
   try {
     // Extract the target property using dot notation
-    const extractedData = targetProperty.split('.').reduce((obj, key) => {
+    const extractedData = targetProperty.split(".").reduce((obj, key) => {
       return obj && obj[key as keyof object];
     }, jsonData);
 
@@ -37,16 +37,19 @@ export async function updateJsonProperty(
   userEmail: string,
   fileName: string,
   targetProperty: string,
-  newValue: string
+  newValue: string,
 ): Promise<void> {
-
   // Get the JSON file from S3 via API endpoint
-  const apiResponse = await fetch(`/api/aws-get?email=${encodeURIComponent(userEmail)}&key=${encodeURIComponent(fileName)}`);
-  
+  const apiResponse = await fetch(
+    `/api/aws-get?email=${encodeURIComponent(userEmail)}&key=${encodeURIComponent(fileName)}`,
+  );
+
   if (!apiResponse.ok) {
-    throw new Error(`Failed to fetch file: ${apiResponse.status} ${apiResponse.statusText}`);
+    throw new Error(
+      `Failed to fetch file: ${apiResponse.status} ${apiResponse.statusText}`,
+    );
   }
-  
+
   const fileContent = await apiResponse.text();
   const jsonData = JSON.parse(fileContent);
 
@@ -54,7 +57,7 @@ export async function updateJsonProperty(
   const existingValue = await GraphDesigner(jsonData, targetProperty);
 
   // Split the property path once
-  const keys = targetProperty.split('.');
+  const keys = targetProperty.split(".");
   const lastKey = keys.pop()!;
 
   // Start from the root JSON data
@@ -69,7 +72,7 @@ export async function updateJsonProperty(
   } else {
     // Property doesn't exist - create the path
     for (const key of keys) {
-      if (!(key in current) || typeof current[key] !== 'object') {
+      if (!(key in current) || typeof current[key] !== "object") {
         current[key] = {};
       }
       current = current[key];
@@ -77,5 +80,5 @@ export async function updateJsonProperty(
     current[lastKey] = newValue;
   }
 
-  console.log('Updated JSON data:', JSON.stringify(jsonData, null, 2));
+  console.log("Updated JSON data:", JSON.stringify(jsonData, null, 2));
 }

--- a/hansroslinger/src/components/interactions/actions/handleVegaInteraction.tsx
+++ b/hansroslinger/src/components/interactions/actions/handleVegaInteraction.tsx
@@ -1,5 +1,6 @@
 import { Visual } from "types/application";
 import { handleHover } from "./handleHover";
+import { canvasStore } from "store/canvasSlice";
 
 // Track last simulated pointer position and target to prevent spamming events
 let lastSimulatedPosition: { x: number; y: number } | null = null;
@@ -55,27 +56,32 @@ const simulatePointerEvents = (
     return;
   }
 
-  // Target the Vega canvas with class 'marks'
-  const canvas = document.querySelector("canvas.marks") as HTMLCanvasElement;
-  if (!canvas) {
-    console.warn("Vega canvas with class 'marks' not found");
+  // Get the canvas used to detect gesture
+  const { gestureCanvas } = canvasStore.getState();
+  if (!gestureCanvas) {
+    console.warn("Canvas used to detect gesture not found");
     return;
   }
 
-  const rect = canvas.getBoundingClientRect();
-
-  // Offset the pointer position by the visual's position
-  const localX = position.x - visual.position.x;
-  const localY = position.y - visual.position.y;
-
+  // Get the client area and calculate the x and y respective to the client bounding area
+  const rect = gestureCanvas.getBoundingClientRect();
   // Map to client coordinates
-  const clientX = rect.left + localX;
-  const clientY = rect.top + localY;
+  const clientX = rect.left + position.x;
+  const clientY = rect.top + position.y;
 
   // Always dispatch events directly to the Vega canvas so the overlay
   // doesn't intercept them. Using `elementFromPoint` here would return the
   // overlay div, preventing Vega from receiving pointer events for tooltips.
-  const target = canvas;
+
+  // When there is multiple vega chart, there can be multiple Vega canvas
+  // To find the right canvas for this specific point, get all the element
+  // under this point and filter of canvas marks.
+  // When there is multiple under the same point, it gets the very top canvas.
+  const stack = document.elementsFromPoint(clientX, clientY);
+  const target = stack.find(
+    (el) => el instanceof HTMLCanvasElement && el.matches("canvas.marks"),
+  ) as HTMLCanvasElement;
+  if (!target) return;
 
   [
     "pointerenter",

--- a/hansroslinger/src/components/interactions/interactionManager.tsx
+++ b/hansroslinger/src/components/interactions/interactionManager.tsx
@@ -150,6 +150,10 @@ export class InteractionManager {
     const point = coordinates[0];
     const target = this.findTargetAt(point);
 
+    if (action !== VEGA_INTERACTION) {
+      handleVegaInteraction(point, null);
+    }
+
     switch (action) {
       case RESIZE: {
         // Point for each hand

--- a/hansroslinger/src/store/canvasSlice.ts
+++ b/hansroslinger/src/store/canvasSlice.ts
@@ -1,0 +1,16 @@
+import { create } from "zustand";
+
+type CanvasState = {
+  gestureCanvas: HTMLCanvasElement | null;
+  setCanvasEl: (el: HTMLCanvasElement | null) => void;
+};
+
+export const useCanvasStore = create<CanvasState>((set) => ({
+  gestureCanvas: null,
+  setCanvasEl: (el) => set({ gestureCanvas: el }),
+}));
+
+// optional non-hook access for utilities
+export const canvasStore = {
+  getState: () => useCanvasStore.getState(),
+};


### PR DESCRIPTION
## hotfix(interaction): Fixed flipped and wrong trigger for vegalite interaction

<!--
Example: feat(UI): Add gesture-based slide navigation

Type options:
- feat: A new feature
- hotfix: A bug fix
- docs: Documentation changes
- style: Code style changes (formatting, missing semicolons, etc.)
- refactor: Code refactoring (non-functional changes)
- test: Adding or modifying tests
- chore: Routine tasks or updates like dependency upgrades
-->

## 📝 Description

<!--
Describe what this PR does, what feature or bug it addresses, and any relevant context.
-->
This PR fixes several things for vegalite interaction:
- The flipped coordinates when using point up for vegalite interaction
- Wrong canvas trigger when there are multiple vegalite chart in one preview session
- When two chart are on top of each other, the top most chart will be the one interaction is triggered on

## ✅ Checklist

<!--
To check, replace space between [] with x, i.e. [x]
-->

### Required

- [x] I have rebased my branch
- [x] I have verified existing tests still pass
- [x] I have run linters and code formatters

### Optional

- [ ] I have added tests for my feature

### For UI/UX PRs:

- [x] I have added a screenshot or screen recording of the feature

## 🖼️ Screenshots / Recordings (For UI/UX PRs)

<!--
If your PR includes UI changes, visual interactions, or animations, please include screenshots or screen recordings here.
-->

https://github.com/user-attachments/assets/0663d1a5-f387-4c61-a000-8cc483e4569f

