### PR TITLE
Feature/fullscreen button

### DIFF
--- a/hansroslinger/src/app/preview/CameraFeed.tsx
+++ b/hansroslinger/src/app/preview/CameraFeed.tsx
@@ -51,9 +51,10 @@ const CameraFeed = () => {
         if (videoRef.current && canvasRef.current) {
           videoRef.current.srcObject = stream;
 
-          // size overlay once laid out and on resize
+          // size overlay once laid out and on resize/fullscreenchange
           requestAnimationFrame(sizeOverlayToVideo);
           window.addEventListener("resize", sizeOverlayToVideo);
+          document.addEventListener("fullscreenchange", sizeOverlayToVideo);
 
           // original detection/render loop
           intervalRef.current = window.setInterval(async () => {
@@ -89,6 +90,7 @@ const CameraFeed = () => {
     const videoElement = videoRef.current;
     return () => {
       window.removeEventListener("resize", sizeOverlayToVideo);
+      document.removeEventListener("fullscreenchange", sizeOverlayToVideo);
       if (intervalRef.current != null) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;

--- a/hansroslinger/src/app/preview/page.tsx
+++ b/hansroslinger/src/app/preview/page.tsx
@@ -3,18 +3,66 @@
 import dynamic from "next/dynamic";
 
 import CanvasOverlay from "@/components/KonvaOverlay";
+import { useEffect, useRef, useState } from "react";
 
 const CameraFeed = dynamic(() => import("./CameraFeed"), {
   ssr: false,
 });
 
 const Preview = () => {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const toggleFullscreen = () => {
+    const target = containerRef.current;
+    if (!target) return;
+
+    const el = target as HTMLElement & {
+      webkitRequestFullscreen?: () => void;
+      msRequestFullscreen?: () => void;
+    };
+    const doc = document as Document & {
+      webkitExitFullscreen?: () => void;
+      msExitFullscreen?: () => void;
+    };
+
+    if (!document.fullscreenElement) {
+      if (el.requestFullscreen) el.requestFullscreen();
+      else if (el.webkitRequestFullscreen) el.webkitRequestFullscreen();
+      else if (el.msRequestFullscreen) el.msRequestFullscreen();
+    } else {
+      if (doc.exitFullscreen) doc.exitFullscreen();
+      else if (doc.webkitExitFullscreen) doc.webkitExitFullscreen();
+      else if (doc.msExitFullscreen) doc.msExitFullscreen();
+    }
+  };
+
+  useEffect(() => {
+    const onChange = () => setIsFullscreen(!!document.fullscreenElement);
+    document.addEventListener("fullscreenchange", onChange);
+    return () => {
+      document.removeEventListener("fullscreenchange", onChange);
+    };
+  }, []);
+
   return (
     <div className="flex justify-center px-4 sm:px-8">
       <div
+        ref={containerRef}
         className="relative w-full max-w-full sm:max-w-2xl md:max-w-4xl lg:max-w-6xl xl:max-w-7xl 
         aspect-video border-2 border-black overflow-hidden bg-black"
       >
+        {/* Fullscreen button — same style as ModeToggle (interact/paint) */}
+        <button
+          onClick={toggleFullscreen}
+          className="absolute top-3 right-3 z-[9999] rounded-2xl px-4 py-2 shadow bg-black/80 text-white"
+          aria-pressed={isFullscreen}
+          aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+          title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
+        >
+          {isFullscreen ? "Exit Fullscreen" : "Fullscreen"}
+        </button>
+
         <CameraFeed />
         <CanvasOverlay />
       </div>

--- a/hansroslinger/src/components/visuals/ImageVisual.tsx
+++ b/hansroslinger/src/components/visuals/ImageVisual.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import React, { useEffect, useMemo, useRef } from "react";
+import React, { useMemo, useRef } from "react";
 import { Visual } from "types/application";
 import { useVisualStore } from "store/visualsSlice";
+import Image from "next/image";
 
 type ImageVisualProp = {
   id: string;
@@ -25,43 +26,18 @@ const ImageVisual = ({ id, visual }: ImageVisualProp) => {
     return "";
   }, [visual.isHovered, visual.isDragging]);
 
-  useEffect(() => {
-    // Create image component
-    const img = new window.Image();
-    img.src = visual.uploadData.src;
-
-    img.onload = () => {
-      // Set original size if first load
-      if (visual.useOriginalSizeOnLoad) {
-        setVisualSize(id, {
-          width: img.naturalWidth,
-          height: img.naturalHeight,
-        });
-        setUseOriginalSizeOnLoad(visual.assetId, false);
-      }
-
-      // Set image property
-      if (containerRef && containerRef.current) {
-        // fit to container
-        img.style.objectFit = "contain";
-        img.style.width = "100%";
-        img.style.height = "100%";
-        // avoid only dragging image
-        img.draggable = false;
-
-        // Clear previous and add image as child
-        containerRef.current.innerHTML = "";
-        containerRef.current.appendChild(img);
-      }
-    };
-  }, [
-    id,
-    visual.uploadData.src,
-    setVisualSize,
-    visual.useOriginalSizeOnLoad,
-    setUseOriginalSizeOnLoad,
-    visual.assetId,
-  ]);
+  const handleImgLoad = (
+    e: React.SyntheticEvent<HTMLImageElement> | { currentTarget: { naturalWidth: number; naturalHeight: number } },
+  ) => {
+    const img = e.currentTarget as HTMLImageElement | { naturalWidth: number; naturalHeight: number };
+    if (visual.useOriginalSizeOnLoad) {
+      setVisualSize(id, {
+        width: img.naturalWidth,
+        height: img.naturalHeight,
+      });
+      setUseOriginalSizeOnLoad(visual.assetId, false);
+    }
+  };
 
   return (
     <div
@@ -98,6 +74,21 @@ const ImageVisual = ({ id, visual }: ImageVisualProp) => {
           />
         </>
       )}
+      {/* Render image via React to avoid manual DOM mutations */}
+      <Image
+        src={visual.uploadData.src}
+        alt=""
+        fill
+        sizes="100vw"
+  onLoad={handleImgLoad}
+        draggable={false}
+        style={{
+          objectFit: "contain",
+          pointerEvents: "none",
+          userSelect: "none",
+        }}
+        priority={true}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## feat(Fullscreen): Added a fullscreen option for gesture control 


## 📝 Description


This PR allows users to select a full screen button on the Yubi preview page, going into full screen bringing all overlayed graphs, images etc. with it. Interaction mode and paint mode remain working in full screen mode.


## ✅ Checklist

<!--
To check, replace space between [] with x, i.e. [x]
-->

### Required

- ✅ I have rebased my branch
- ✅ I have verified existing tests still pass
- ✅ I have run linters and code formatters

### Optional

- [ ] I have added tests for my feature

### For UI/UX PRs:

- [ ] I have added a screenshot or screen recording of the feature

## 🖼️ Screenshots / Recordings (For UI/UX PRs)


<img width="3439" height="1348" alt="image" src="https://github.com/user-attachments/assets/2b6375ed-b448-4204-9646-ed536eeb85eb" />

<img width="3439" height="1439" alt="image" src="https://github.com/user-attachments/assets/05dc3996-3dd3-4e26-97b0-e9d43a17d343" />

<img width="3439" height="1439" alt="image" src="https://github.com/user-attachments/assets/f19d5658-e38e-43fe-ad88-98f93ebab20f" />
